### PR TITLE
Fix expires_in field as str, update tests (fixes #26)

### DIFF
--- a/requests_oauth2client/utils.py
+++ b/requests_oauth2client/utils.py
@@ -61,13 +61,20 @@ def accepts_expires_in(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
     def decorator(
         *args: Any,
-        expires_in: int | None = None,
+        expires_in: int | str | None = None,
         expires_at: datetime | None = None,
         **kwargs: Any,
     ) -> Any:
         if expires_in is None and expires_at is None:
             return f(*args, **kwargs)
-        if expires_in and isinstance(expires_in, int) and expires_in >= 1:
+        if (
+            expires_in
+            and isinstance(expires_in, str)
+            and expires_in.isdigit()
+            and int(expires_in) >= 1
+        ):
+            expires_at = datetime.now() + timedelta(seconds=int(expires_in))
+        elif expires_in and isinstance(expires_in, int) and expires_in >= 1:
             expires_at = datetime.now() + timedelta(seconds=expires_in)
         return f(*args, expires_at=expires_at, **kwargs)
 

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -17,7 +17,8 @@ def test_validate_uri() -> None:
         validate_endpoint_uri("https://myas.local/token#foo")
 
 
-def test_accepts_expires_in() -> None:
+@pytest.mark.parametrize("expires_in", [10, "10"])
+def test_accepts_expires_in(expires_in: int | str) -> None:
     @accepts_expires_in
     def foo(expires_at: datetime | None = None) -> datetime | None:
         return expires_at
@@ -25,5 +26,5 @@ def test_accepts_expires_in() -> None:
     now = datetime.now()
     assert foo(expires_at=now) == now
     assert foo(now) == now
-    assert isinstance(foo(expires_in=10), datetime)
+    assert isinstance(foo(expires_in=expires_in), datetime)
     assert foo() is None


### PR DESCRIPTION
Fixes issue #26 

Added the str -> int fix I originally suggested in issue #26. 
Also added a test case for when `expires_in` field comes in as a str.

All tests and pre-commit checks pass locally