### PR TITLE
Fix incorrect `jwks_uri` validation in OAuth2 client (Fixes #34)

### DIFF
--- a/requests_oauth2client/client.py
+++ b/requests_oauth2client/client.py
@@ -1315,7 +1315,7 @@ class OAuth2Client:
             validate_endpoint_uri(userinfo_endpoint, https=https)
         jwks_uri = discovery.get("jwks_uri")
         if jwks_uri is not None:
-            validate_endpoint_uri(userinfo_endpoint, https=https)
+            validate_endpoint_uri(jwks_uri, https=https)
         authorization_response_iss_parameter_supported = discovery.get(
             "authorization_response_iss_parameter_supported", False
         )


### PR DESCRIPTION
The uri passed to validate_endpoint_uri function was incorrect when checking `jwks_uri` from the discovery document, previously it was mistakenly validating `userinfo_endpoint` again. This commit fixes the issue by validating `jwks_uri` instead.