### PR TITLE
enforce endpoint uri validation

### DIFF
--- a/requests_oauth2client/__init__.py
+++ b/requests_oauth2client/__init__.py
@@ -21,6 +21,7 @@ from .authorization_request import (
     AuthorizationRequest,
     AuthorizationRequestSerializer,
     AuthorizationResponse,
+    CodeChallengeMethods,
     PkceUtils,
     RequestParameterAuthorizationRequest,
     RequestUriParameterAuthorizationRequest,
@@ -32,6 +33,7 @@ from .backchannel_authentication import (
 from .client import (
     GrantType,
     OAuth2Client,
+    TestingOAuth2Client,
 )
 from .client_authentication import (
     BaseClientAuthenticationMethod,
@@ -128,6 +130,7 @@ __all__ = [
     "ClientSecretBasic",
     "ClientSecretJwt",
     "ClientSecretPost",
+    "CodeChallengeMethods",
     "ConsentRequired",
     "DeviceAuthorizationError",
     "DeviceAuthorizationPoolingJob",
@@ -181,6 +184,7 @@ __all__ = [
     "SessionSelectionRequired",
     "SignatureAlgs",
     "SlowDown",
+    "TestingOAuth2Client",
     "TokenEndpointError",
     "TokenEndpointPoolingJob",
     "UnauthorizedClient",

--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import secrets
 from datetime import datetime
+from enum import Enum
 from typing import Any, Callable, ClassVar, Iterable, Sequence
 
 from attrs import Factory, asdict, field, fields, frozen
@@ -105,6 +106,13 @@ class PkceUtils:
 
         """
         return cls.code_verifier_re.match(verifier) is not None and cls.derive_challenge(verifier, method) == challenge
+
+
+class CodeChallengeMethods(str, Enum):
+    """PKCE Code Challenge Methods."""
+
+    plain = "plain"
+    S256 = "S256"
 
 
 @frozen(init=False)

--- a/requests_oauth2client/utils.py
+++ b/requests_oauth2client/utils.py
@@ -13,12 +13,22 @@ from typing import Any, Callable
 from furl import furl  # type: ignore[import-untyped]
 
 
-def validate_endpoint_uri(uri: str, *, https: bool = True, no_fragment: bool = True, path: bool = True) -> None:
+def validate_endpoint_uri(
+    uri: str,
+    *,
+    https: bool = True,
+    no_credentials: bool = True,
+    no_port: bool = True,
+    no_fragment: bool = True,
+    path: bool = True,
+) -> str:
     """Validate that a URI is suitable as an endpoint URI.
 
     It checks:
 
     - that the scheme is `https`
+    - that no custom port number is being used
+    - that no username or password are included
     - that no fragment is included
     - that a path is present
 
@@ -31,24 +41,44 @@ def validate_endpoint_uri(uri: str, *, https: bool = True, no_fragment: bool = T
     Args:
         uri: the uri
         https: if `True`, check that the uri is https
+        no_port: if `True`, check that no custom port number is included
+        no_credentials: if ` True`, check that no username/password are included
         no_fragment: if `True`, check that the uri contains no fragment
         path: if `True`, check that the uri contains a path component
 
     Raises:
         ValueError: if the supplied url is not suitable
 
+    Returns:
+        the endpoint URI, if all checks passed
+
     """
     url = furl(uri)
     msg: list[str] = []
     if https and url.scheme != "https":
-        msg += "url must use https"
+        msg.append("url must use https")
+    if no_port and url.port != 443:  # noqa: PLR2004
+        msg.append("no custom port number allowed")
+    if no_credentials and url.username or url.password:
+        msg.append("no username or password are allowed")
     if no_fragment and url.fragment:
-        msg += "url must not contain a fragment"
+        msg.append("url must not contain a fragment")
     if path and (not url.path or url.path == "/"):
-        msg += "url has no path"
+        msg.append("url has no path")
 
     if msg:
         raise ValueError(", ".join(msg))
+
+    return uri
+
+
+def validate_issuer_uri(uri: str) -> str:
+    """Validate that an Issuer Identifier URI is valid.
+
+    This is almost the same as a valid endpoint URI, but a path is not mandatory.
+
+    """
+    return validate_endpoint_uri(uri, path=False)
 
 
 def accepts_expires_in(f: Callable[..., Any]) -> Callable[..., Any]:

--- a/requests_oauth2client/vendor_specific/auth0.py
+++ b/requests_oauth2client/vendor_specific/auth0.py
@@ -55,11 +55,12 @@ class Auth0:
     ) -> OAuth2Client:
         """Initialise an OAuth2Client for an Auth0 tenant."""
         tenant = cls.tenant(tenant)
-        token_endpoint = f"https://{tenant}/oauth/token"
-        authorization_endpoint = f"https://{tenant}/authorize"
-        revocation_endpoint = f"https://{tenant}/oauth/revoke"
-        userinfo_endpoint = f"https://{tenant}/userinfo"
-        jwks_uri = f"https://{tenant}/.well-known/jwks.json"
+        issuer = f"https://{tenant}"
+        token_endpoint = f"{issuer}/oauth/token"
+        authorization_endpoint = f"{issuer}/authorize"
+        revocation_endpoint = f"{issuer}/oauth/revoke"
+        userinfo_endpoint = f"{issuer}/userinfo"
+        jwks_uri = f"{issuer}/.well-known/jwks.json"
 
         return OAuth2Client(
             auth=auth,
@@ -71,7 +72,7 @@ class Auth0:
             authorization_endpoint=authorization_endpoint,
             revocation_endpoint=revocation_endpoint,
             userinfo_endpoint=userinfo_endpoint,
-            issuer=tenant,
+            issuer=issuer,
             jwks_uri=jwks_uri,
             **kwargs,
         )

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -49,8 +49,8 @@ def test_encrypted_id_token(requests_mock: RequestsMocker) -> None:
             "kid": "Vs6sw5LGsEYfeiAs3rwiOwXKJpw4S926IaOpefvm-Ec",
         }
     )
-    token_endpoint = "https://token.endpoint"
-    authorization_endpoint = "https://authorization.endpoint"
+    token_endpoint = "https://as.local/token"
+    authorization_endpoint = "https://as.local/authorize"
     issuer = "https://issuer"
 
     claims = {"iss": issuer, "iat": Jwt.timestamp(), "exp": Jwt.timestamp(60), "sub": subject, "nonce": nonce}

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -617,6 +617,17 @@ def test_from_discovery_document(
             auth=client_id,
         )
 
+    with pytest.warns(match="https parameter is deprecated"):
+        OAuth2Client.from_discovery_document({
+            "issuer": issuer,
+            "token_endpoint": token_endpoint,
+            "revocation_endpoint": revocation_endpoint,
+            "introspection_endpoint": introspection_endpoint,
+            "userinfo_endpoint": userinfo_endpoint,
+            "jwks_uri": jwks_uri,
+        }, issuer=issuer,
+        auth=client_id,https=False)
+
 
 def test_from_discovery_document_missing_token_endpoint(revocation_endpoint: str, client_id: str) -> None:
     """Invalid discovery documents raises an exception."""
@@ -1454,7 +1465,10 @@ def test_testing_oauth2client() -> None:
     test_client = TestingOAuth2Client(
         token_endpoint=token_endpoint,
         client_id="foo",
-        client_secret="bar"
+        client_secret="bar",
+        issuer="http://localhost:1234",
     )
 
     assert test_client.token_endpoint == token_endpoint
+
+

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -9,12 +9,16 @@ from requests_oauth2client.utils import accepts_expires_in, validate_endpoint_ur
 
 def test_validate_uri() -> None:
     validate_endpoint_uri("https://myas.local/token")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="https"):
         validate_endpoint_uri("http://myas.local/token")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="path"):
         validate_endpoint_uri("https://myas.local")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="fragment"):
         validate_endpoint_uri("https://myas.local/token#foo")
+    with pytest.raises(ValueError, match="username"):
+        validate_endpoint_uri("https://user:passwd@myas.local/token")
+    with pytest.raises(ValueError, match="port"):
+        validate_endpoint_uri("https://myas.local:1234/token")
 
 
 @pytest.mark.parametrize("expires_in", [10, "10"])


### PR DESCRIPTION
Makes sure that endpoint URIs provided to `OAuth2Client` are suitable (use https, no fragment, etc.)
Introduce ` TestingOAuth2Client` which disables those checks.