### PR TITLE
better endpoint uri validation

### DIFF
--- a/requests_oauth2client/__init__.py
+++ b/requests_oauth2client/__init__.py
@@ -33,7 +33,6 @@ from .backchannel_authentication import (
 from .client import (
     GrantType,
     OAuth2Client,
-    TestingOAuth2Client,
 )
 from .client_authentication import (
     BaseClientAuthenticationMethod,
@@ -184,7 +183,6 @@ __all__ = [
     "SessionSelectionRequired",
     "SignatureAlgs",
     "SlowDown",
-    "TestingOAuth2Client",
     "TokenEndpointError",
     "TokenEndpointPoolingJob",
     "UnauthorizedClient",

--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -314,12 +314,12 @@ class AuthorizationRequest:
         if state is ...:
             state = self.generate_state()
         if state is not None and not isinstance(state, str):
-            state = str(state)
+            state = str(state)  # pragma: no cover
 
         if nonce is ...:
             nonce = self.generate_nonce() if scope is not None and "openid" in scope else None
         if nonce is not None and not isinstance(nonce, str):
-            nonce = str(nonce)
+            nonce = str(nonce)  # pragma: no cover
 
         if not scope:
             scope = None

--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -6,7 +6,6 @@ import re
 import secrets
 from datetime import datetime
 from enum import Enum
-from types import EllipsisType
 from typing import Any, Callable, ClassVar, Iterable, Sequence
 
 from attrs import Factory, asdict, field, fields, frozen
@@ -312,11 +311,15 @@ class AuthorizationRequest:
             )
             raise ValueError(msg)
 
-        if isinstance(state, EllipsisType):
+        if state is ...:
             state = self.generate_state()
+        if state is not None and not isinstance(state, str):
+            state = str(state)
 
-        if isinstance(nonce, EllipsisType):
+        if nonce is ...:
             nonce = self.generate_nonce() if scope is not None and "openid" in scope else None
+        if nonce is not None and not isinstance(nonce, str):
+            nonce = str(nonce)
 
         if not scope:
             scope = None

--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -6,6 +6,7 @@ import re
 import secrets
 from datetime import datetime
 from enum import Enum
+from types import EllipsisType
 from typing import Any, Callable, ClassVar, Iterable, Sequence
 
 from attrs import Factory, asdict, field, fields, frozen
@@ -311,10 +312,10 @@ class AuthorizationRequest:
             )
             raise ValueError(msg)
 
-        if state is Ellipsis:
+        if isinstance(state, EllipsisType):
             state = self.generate_state()
 
-        if nonce is Ellipsis:
+        if isinstance(nonce, EllipsisType):
             nonce = self.generate_nonce() if scope is not None and "openid" in scope else None
 
         if not scope:

--- a/requests_oauth2client/utils.py
+++ b/requests_oauth2client/utils.py
@@ -64,7 +64,7 @@ def validate_endpoint_uri(
     if no_fragment and url.fragment:
         msg.append("url must not contain a fragment")
     if path and (not url.path or url.path == "/"):
-        msg.append("url has no path")
+        msg.append("url must include a path")
 
     if msg:
         raise ValueError(", ".join(msg))

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -28,7 +28,6 @@ from requests_oauth2client import (
     UnauthorizedClient,
     UnknownIntrospectionError,
     oidc_discovery_document_url,
-    TestingOAuth2Client,
 )
 from tests.conftest import RequestsMocker, RequestValidatorType
 
@@ -1462,11 +1461,12 @@ def test_testing_oauth2client() -> None:
     with pytest.raises(ValueError, match="must use https"):
         OAuth2Client(token_endpoint=token_endpoint, client_id="client_id")
 
-    test_client = TestingOAuth2Client(
+    test_client = OAuth2Client(
         token_endpoint=token_endpoint,
         client_id="foo",
         client_secret="bar",
         issuer="http://localhost:1234",
+        testing=True,
     )
 
     assert test_client.token_endpoint == token_endpoint

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1463,10 +1463,10 @@ def test_testing_oauth2client() -> None:
         OAuth2Client(token_endpoint=token_endpoint, client_id="client_id")
 
     with pytest.raises(ValueError, match="must use https"):
-        OAuth2Client(token_endpoint=token_endpoint, client_id="client_id", issuer=issuer)
+        OAuth2Client(token_endpoint="https://valid.token/endpoint", client_id="client_id", issuer=issuer)
 
     with pytest.raises(ValueError, match="no custom port number allowed"):
-        OAuth2Client(token_endpoint=token_endpoint, client_id="client_id", issuer=issuer)
+        OAuth2Client(token_endpoint="https://valid.token/endpoint", client_id="client_id", issuer=issuer)
 
     with pytest.raises(ValueError, match="must include a path"):
         OAuth2Client(token_endpoint="https://foo.bar/", client_id="client_id")

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1456,19 +1456,30 @@ def test_client_custom_auth_method() -> None:
 
 
 def test_testing_oauth2client() -> None:
+    issuer="http://localhost:1234"
     token_endpoint = "http://localhost:1234/token"
 
     with pytest.raises(ValueError, match="must use https"):
         OAuth2Client(token_endpoint=token_endpoint, client_id="client_id")
 
+    with pytest.raises(ValueError, match="must use https"):
+        OAuth2Client(token_endpoint=token_endpoint, client_id="client_id", issuer=issuer)
+
+    with pytest.raises(ValueError, match="no custom port number allowed"):
+        OAuth2Client(token_endpoint=token_endpoint, client_id="client_id", issuer=issuer)
+
+    with pytest.raises(ValueError, match="must include a path"):
+        OAuth2Client(token_endpoint="https://foo.bar/", client_id="client_id")
+
     test_client = OAuth2Client(
         token_endpoint=token_endpoint,
         client_id="foo",
         client_secret="bar",
-        issuer="http://localhost:1234",
+        issuer=issuer,
         testing=True,
     )
 
     assert test_client.token_endpoint == token_endpoint
+    assert test_client.issuer == issuer
 
 


### PR DESCRIPTION
- use `attrs` validators
- remove `TestingOAuth2Client`
- use a `testing` parameter for OAuth2Client instead