### PR TITLE
Allow using custom ports in endpoints without using `testing=True`, as discussed in #55

### DIFF
--- a/requests_oauth2client/client.py
+++ b/requests_oauth2client/client.py
@@ -1679,31 +1679,37 @@ Invalid `token_type_hint`. To test arbitrary `token_type_hint` values, you must 
         testing: bool = False,
         **kwargs: Any,
     ) -> OAuth2Client:
-        """Initialise an OAuth2Client based on Authorization Server Metadata.
+        """Initialize an `OAuth2Client` using an AS Discovery Document endpoint.
 
-        This will retrieve the standardized metadata document available at `url`, and will extract
+        If an `url` is provided, an HTTPS request will be done to that URL to obtain the Authorization Server Metadata.
+
+        If an `issuer` is provided, the OpenID Connect Discovery document url will be automatically
+        derived from it, as specified in [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest).
+
+        Once the standardized metadata document is obtained, this will extract
         all Endpoint Uris from that document, will fetch the current public keys from its
-        `jwks_uri`, then will initialise an OAuth2Client based on those endpoints.
+        `jwks_uri`, then will initialize an OAuth2Client based on those endpoints.
 
         Args:
-             url: the url where the server metadata will be retrieved
-             auth: the authentication handler to use for client authentication
-             client_id: client ID
-             client_secret: client secret to use to authenticate the client
-             private_key: private key to sign client assertions
-             session: a `requests.Session` to use to retrieve the document and initialise the client with
-             issuer: if an issuer is given, check that it matches the one from the retrieved document
-             testing: if `True`, do not try to validate the issuer uri nor the endpoint urls
-                 that are part of the document
-             **kwargs: additional keyword parameters to pass to OAuth2Client
+          url: The url where the server metadata will be retrieved.
+          issuer: The issuer value that is expected in the discovery document.
+            If not `url` is given, the OpenID Connect Discovery url for this issuer will be retrieved.
+          auth: The authentication handler to use for client authentication.
+          client_id: Client ID.
+          client_secret: Client secret to use to authenticate the client.
+          private_key: Private key to sign client assertions.
+          session: A `requests.Session` to use to retrieve the document and initialise the client with.
+          testing: If `True`, do not try to validate the issuer uri nor the endpoint urls
+            that are part of the document.
+          **kwargs: Additional keyword parameters to pass to `OAuth2Client`.
 
         Returns:
-            an OAuth2Client with endpoint initialized based on the obtained metadata
+          An `OAuth2Client` with endpoints initialized based on the obtained metadata.
 
         Raises:
-            InvalidIssuer: If `issuer` is not using https, or contains credentials or fragment.
-            InvalidParam: If neither `url` nor `issuer` are suitable urls.
-            requests.HTTPError: If an error happens while fetching the documents.
+          InvalidIssuer: If `issuer` is not using https, or contains credentials or fragment.
+          InvalidParam: If neither `url` nor `issuer` are suitable urls.
+          requests.HTTPError: If an error happens while fetching the documents.
 
         Example:
             ```python
@@ -1761,31 +1767,43 @@ Invalid `token_type_hint`. To test arbitrary `token_type_hint` values, you must 
         client_secret: str | None = None,
         private_key: Jwk | dict[str, Any] | None = None,
         authorization_server_jwks: JwkSet | dict[str, Any] | None = None,
-        session: requests.Session | None = None,
         https: bool = True,
         testing: bool = False,
         **kwargs: Any,
     ) -> OAuth2Client:
-        """Initialize an OAuth2Client, based on the server metadata from `discovery`.
+        """Initialize an `OAuth2Client`, based on an AS Discovery Document.
 
         Args:
-             discovery: a dict of server metadata, in the same format as retrieved from a discovery endpoint.
-             issuer: if an issuer is given, check that it matches the one mentioned in the document
-             auth: the authentication handler to use for client authentication
-             client_id: client ID
-             client_secret: client secret to use to authenticate the client
-             private_key: private key to sign client assertions
-             authorization_server_jwks: the current authorization server JWKS keys
-             session: a requests Session to use to retrieve the document and initialize the client with
-             https: (deprecated) if `True`, validates that urls in the discovery document use the https scheme
-             testing: if `True`, don't try to validate the endpoint urls that are part of the document
-             **kwargs: additional args that will be passed to OAuth2Client
+          discovery: A `dict` of server metadata, in the same format as retrieved from a discovery endpoint.
+          issuer: If an issuer is given, check that it matches the one mentioned in the document.
+          auth: The authentication handler to use for client authentication.
+          client_id: Client ID.
+          client_secret: Client secret to use to authenticate the client.
+          private_key: Private key to sign client assertions.
+          authorization_server_jwks: The current authorization server JWKS keys.
+          https: (deprecated) If `True`, validates that urls in the discovery document use the https scheme.
+          testing: If `True`, don't try to validate the endpoint urls that are part of the document.
+          **kwargs: Additional args that will be passed to `OAuth2Client`.
 
         Returns:
-            an `OAuth2Client` initialized with the endpoints from the discovery document
+            An `OAuth2Client` initialized with the endpoints from the discovery document.
 
         Raises:
-            InvalidDiscoveryDocument: if the document does not contain at least a `"token_endpoint"`.
+            InvalidDiscoveryDocument: If the document does not contain at least a `"token_endpoint"`.
+
+        Examples:
+            ```python
+            from requests_oauth2client import OAuth2Client
+
+            client = OAuth2Client.from_discovery_document(
+                {
+                    "issuer": "https://myas.local",
+                    "token_endpoint": "https://myas.local/token",
+                },
+                client_id="client_id",
+                client_secret="client_secret",
+            )
+            ```
 
         """
         if not https:
@@ -1835,7 +1853,6 @@ Mismatching `issuer` value in discovery document (received '{discovery.get('issu
             client_id=client_id,
             client_secret=client_secret,
             private_key=private_key,
-            session=session,
             issuer=issuer,
             authorization_response_iss_parameter_supported=authorization_response_iss_parameter_supported,
             testing=testing,

--- a/requests_oauth2client/utils.py
+++ b/requests_oauth2client/utils.py
@@ -51,7 +51,7 @@ def validate_endpoint_uri(
     *,
     https: bool = True,
     no_credentials: bool = True,
-    no_port: bool = True,
+    no_port: bool = False,
     no_fragment: bool = True,
     path: bool = True,
 ) -> str:

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -19,8 +19,11 @@ from requests_oauth2client import (
     ClientSecretPost,
     DeviceAuthorizationResponse,
     IdToken,
+    InvalidIssuer,
+    InvalidParam,
     InvalidPushedAuthorizationResponse,
     InvalidTokenResponse,
+    InvalidUri,
     OAuth2Client,
     PrivateKeyJwt,
     PublicApp,
@@ -1516,9 +1519,6 @@ def test_testing_oauth2client() -> None:
     with pytest.raises(ValueError, match="must use https"):
         OAuth2Client(token_endpoint="https://valid.token/endpoint", client_id="client_id", issuer=issuer)
 
-    with pytest.raises(ValueError, match="no custom port number allowed"):
-        OAuth2Client(token_endpoint="https://valid.token/endpoint", client_id="client_id", issuer=issuer)
-
     with pytest.raises(ValueError, match="must include a path"):
         OAuth2Client(token_endpoint="https://foo.bar/", client_id="client_id")
 
@@ -1546,3 +1546,52 @@ def test_proxy_authorization(requests_mock: RequestsMocker, target_api: str) -> 
     requests.post(target_api, auth=ProxyAuthorizationBearerToken(access_token))
     assert requests_mock.last_request is not None
     assert requests_mock.last_request.headers[auth_header] == f"Bearer {access_token}"
+
+
+def test_custom_ports_in_endpoints(requests_mock: RequestsMocker) -> None:
+    issuer = "https://as.local:8443"
+    token_endpoint = "https://as.local:8443/token"
+    client = OAuth2Client(token_endpoint=token_endpoint, client_id="client_id", client_secret="client_secret")
+    assert client.token_endpoint == token_endpoint
+
+    assert not requests_mock.called_once
+    with pytest.raises(InvalidIssuer, match="must use https"):
+        OAuth2Client.from_discovery_endpoint(issuer="http://as.local")
+    assert not requests_mock.called_once
+
+    with pytest.raises(InvalidIssuer, match="must use https"):
+        OAuth2Client.from_discovery_endpoint(issuer="http://as.local:8080")
+    assert not requests_mock.called_once
+
+    with pytest.raises(InvalidUri, match="must use https"):
+        OAuth2Client.from_discovery_endpoint(url="http://as.local/.well-known/openid-configuration")
+    assert not requests_mock.called_once
+
+    requests_mock.get(
+        "https://as.local/.well-known/openid-configuration", json={"issuer": issuer, "token_endpoint": token_endpoint}
+    )
+    with pytest.raises(
+        InvalidParam,
+        match=rf"Mismatching `issuer` value in discovery document \(received '{issuer}', expected 'https://as.local'\)",
+    ):
+        OAuth2Client.from_discovery_endpoint(issuer="https://as.local", client_id="client_id")
+    assert requests_mock.called_once
+
+    discovery_url = "https://as.local:8443/.well-known/openid-configuration"
+    requests_mock.get(discovery_url, json={"issuer": issuer, "token_endpoint": token_endpoint})
+
+    requests_mock.reset()
+    assert (
+        OAuth2Client.from_discovery_endpoint(
+            url="https://as.local:8443/.well-known/openid-configuration", client_id="client_id"
+        ).token_endpoint
+        == token_endpoint
+    )
+    assert requests_mock.called_once
+
+    requests_mock.reset()
+    assert (
+        OAuth2Client.from_discovery_endpoint(issuer="https://as.local:8443", client_id="client_id").token_endpoint
+        == token_endpoint
+    )
+    assert requests_mock.called_once

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -661,7 +661,7 @@ def test_from_discovery_document(
             auth=client_id,
         )
 
-    with pytest.warns(match="https parameter is deprecated"):
+    with pytest.warns(match="`https` parameter is deprecated"):
         OAuth2Client.from_discovery_document(
             {
                 "issuer": issuer,

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -22,9 +22,6 @@ def test_validate_uri() -> None:
     with pytest.raises(ValueError, match="credentials") as exc:
         validate_endpoint_uri("https://user:passwd@myas.local/token")
     assert exc.type is InvalidUri
-    with pytest.raises(ValueError, match="port") as exc:
-        validate_endpoint_uri("https://myas.local:1234/token")
-    assert exc.type is InvalidUri
 
 
 @pytest.mark.parametrize("expires_in", [10, "10"])

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -22,6 +22,9 @@ def test_validate_uri() -> None:
     with pytest.raises(ValueError, match="credentials") as exc:
         validate_endpoint_uri("https://user:passwd@myas.local/token")
     assert exc.type is InvalidUri
+    with pytest.raises(ValueError, match="port") as exc:
+        validate_endpoint_uri("https://myas.local:1234/token", no_port=True)
+    assert exc.type is InvalidUri
 
 
 @pytest.mark.parametrize("expires_in", [10, "10"])

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -10,6 +10,7 @@ from requests_oauth2client.utils import accepts_expires_in
 
 def test_validate_uri() -> None:
     validate_endpoint_uri("https://myas.local/token")
+    validate_endpoint_uri("https://myas.local:443/token", no_port=True)
     with pytest.raises(ValueError, match="https") as exc:
         validate_endpoint_uri("http://myas.local/token")
     assert exc.type is InvalidUri


### PR DESCRIPTION
- Remove the check for custom port in endpoint uri validation.
- Validate the `issuer` and/or url values before doing any HTTP request in `OAuth2Client.from_discovery_endpoint()`, unless `testing=True` is used. 
- if `testing=True`, don't try to validate the `jwks_uri` in `OAuth2Client.from_discovery_document()`