### PR TITLE
Add DPoP key support to AuthorizationRequestSerializer (#119)

### DIFF
--- a/requests_oauth2client/authorization_request.py
+++ b/requests_oauth2client/authorization_request.py
@@ -941,7 +941,7 @@ class AuthorizationRequestSerializer:
         """
         d = asdict(azr)
         if azr.dpop_key:
-            d["dpop_key"]["private_key"] = azr.dpop_key.private_key.to_pem()
+            d["dpop_key"]["private_key"] = azr.dpop_key.private_key.to_dict()
         d.update(**d.pop("kwargs", {}))
         return BinaPy.serialize_to("json", d).to("deflate").to("b64u").ascii()
 
@@ -965,7 +965,7 @@ class AuthorizationRequestSerializer:
         args = BinaPy(serialized).decode_from("b64u").decode_from("deflate").parse_from("json")
 
         if dpop_key := args.get("dpop_key"):
-            dpop_key["private_key"] = Jwk.from_pem(dpop_key["private_key"])
+            dpop_key["private_key"] = Jwk(dpop_key["private_key"])
             dpop_key.pop("jti_generator", None)
             dpop_key.pop("iat_generator", None)
             dpop_key.pop("dpop_token_class", None)

--- a/tests/unit_tests/test_authorization_request.py
+++ b/tests/unit_tests/test_authorization_request.py
@@ -204,8 +204,10 @@ def test_authorization_request_serializer_with_dpop_key() -> None:
         dpop_key=dpop_key,
     )
 
-    serialized = AuthorizationRequestSerializer.default_dumper(authorization_request)
-    deserialized_request = AuthorizationRequestSerializer.default_loader(serialized)
+    serializer = AuthorizationRequestSerializer()
+
+    serialized = serializer.dumps(authorization_request)
+    deserialized_request = serializer.loads(serialized)
 
     assert isinstance(deserialized_request.dpop_key, DPoPKey)
     assert deserialized_request.dpop_key.private_key == dpop_key.private_key

--- a/tests/unit_tests/test_authorization_request.py
+++ b/tests/unit_tests/test_authorization_request.py
@@ -12,6 +12,7 @@ from requests_oauth2client import (
     AuthorizationRequestSerializer,
     AuthorizationResponse,
     AuthorizationResponseError,
+    DPoPKey,
     InvalidMaxAgeParam,
     MismatchingIssuer,
     MismatchingState,
@@ -191,6 +192,23 @@ def test_authorization_request_serializer(authorization_request: AuthorizationRe
     serializer = AuthorizationRequestSerializer()
     serialized = serializer.dumps(authorization_request)
     assert serializer.loads(serialized) == authorization_request
+
+
+def test_authorization_request_serializer_with_dpop_key() -> None:
+    dpop_key = DPoPKey.generate()
+    authorization_request = AuthorizationRequest(
+        "https://as.local/authorize",
+        client_id="foo",
+        redirect_uri="http://localhost/local",
+        scope="openid",
+        dpop_key=dpop_key,
+    )
+
+    serialized = AuthorizationRequestSerializer.default_dumper(authorization_request)
+    deserialized_request = AuthorizationRequestSerializer.default_loader(serialized)
+
+    assert isinstance(deserialized_request.dpop_key, DPoPKey)
+    assert deserialized_request.dpop_key.private_key == dpop_key.private_key
 
 
 def test_request_acr_values() -> None:


### PR DESCRIPTION
fixes #119

@guillp not sure about the style here; feel free to revise mercilessly.

One concern I have is that this doesn't handle `jti_generator`, `iat_generator`, or `dpop_token_class`, which are obviously trickier to serialize/deserialize. Let me know what you think.