### PR TITLE
fix FlaskOAuth2ClientCredentialsAuth so that it supports the token kwarg

### DIFF
--- a/requests_oauth2client/flask/auth.py
+++ b/requests_oauth2client/flask/auth.py
@@ -30,9 +30,9 @@ class FlaskSessionAuthMixin:
         *args: Any,
         **token_kwargs: Any,
     ) -> None:
-        super().__init__(*args, **token_kwargs)
         self.serializer = serializer or BearerTokenSerializer()
         self.session_key = session_key
+        super().__init__(*args, **token_kwargs)
 
     @property
     def token(self) -> BearerToken | None:

--- a/tests/unit_tests/test_flask.py
+++ b/tests/unit_tests/test_flask.py
@@ -2,7 +2,6 @@ from typing import Any, Iterable
 from urllib.parse import parse_qs
 
 import pytest
-from flask import request
 
 from requests_oauth2client import ApiClient, ClientSecretPost, OAuth2Client
 from tests.conftest import RequestsMocker
@@ -20,7 +19,7 @@ def test_flask(
 ) -> None:
     try:
         from flask import Flask
-
+        from flask import request
         from requests_oauth2client.flask import FlaskOAuth2ClientCredentialsAuth
     except ImportError:
         pytest.skip("Flask is not available")
@@ -99,3 +98,24 @@ def test_flask(
     api_request3 = requests_mock.request_history[4]
     assert api_request3.url == "https://myapi.local/root/?call=3"
     assert api_request3.headers.get("Authorization") == f"Bearer {access_token}"
+
+
+def test_flask_token_kwarg() -> None:
+    try:
+        from flask import Flask
+
+        from requests_oauth2client.flask import FlaskOAuth2ClientCredentialsAuth
+    except ImportError:
+        pytest.skip("Flask is not available")
+
+    app = Flask("testapp")
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "thisissecret"
+
+    with app.test_request_context('/'):
+        auth = FlaskOAuth2ClientCredentialsAuth(
+            client=None,
+            session_key=session_key,
+            token="xyz",
+        )
+        assert auth.token.access_token == "xyz"


### PR DESCRIPTION
If the user passes token into the FlaskOAuth2ClientCredentialsAuth constructor, it needs serializer and session_key set before it runs the superclass constructor(s). Without this, the test fails with:

```
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "/requests_oauth2client/flask/auth.py", line 33, in __init__
    super().__init__(*args, **token_kwargs)
  File ".../requests_oauth2client/auth.py", line 69, in __init__
    self.__attrs_init__(client=client, token=token, leeway=leeway, token_kwargs=token_kwargs)
  File "<attrs generated init requests_oauth2client.auth.OAuth2AccessTokenAuth>", line 4, in __attrs_init__
  File ".../site-packages/attr/_make.py", line 1121, in __setattr__
    _OBJ_SETATTR(self, name, nval)
  File ".../requests_oauth2client/flask/auth.py", line 61, in token
    serialized_token = self.serializer.dumps(token)
                       ^^^^^^^^^^^^^^^
AttributeError: 'FlaskTokenAuth' object has no attribute 'serializer'
```