### PR TITLE
pool -> poll

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -437,12 +437,12 @@ gYK-ZnQfoat2bghwed7oEz--wvn4D70ksJ5GuWO9sXXygZ7PMnUlSpBmMCcNRHxdgTS9m_roYwGxF6HQ
 ### Device Authorization Grant
 
 Helpers for the Device Authorization Grant are also included. To get device and user codes, read the response attributes
-(including Device Code, User Code, Verification URI, etc.), then pooling the Token Endpoint:
+(including Device Code, User Code, Verification URI, etc.), then polling the Token Endpoint:
 
 ```python
 from requests_oauth2client import (
     BearerToken,
-    DeviceAuthorizationPoolingJob,
+    DeviceAuthorizationPollingJob,
     OAuth2Client,
 )
 
@@ -465,17 +465,17 @@ assert da_resp.interval
 # Send/show the Verification Uri and User Code to the user. They must use a browser to visit that URL, authenticate, and input the User Code.
 
 # You can then request the Token endpoint to check if the user successfully authorized your device like this:
-pool_job = DeviceAuthorizationPoolingJob(client, da_resp)
+polling_job = DeviceAuthorizationPollingJob(client, da_resp)
 
 resp = None
 while resp is None:
-    resp = pool_job()
+    resp = polling_job()
 
 assert isinstance(resp, BearerToken)
 ```
 
-[DeviceAuthorizationPoolingJob](https://guillp.github.io/requests_oauth2client/api/#requests_oauth2client.device_authorization.DeviceAuthorizationPoolingJob)
-will automatically obey the pooling period. Everytime you call `pool_job()`, it will wait the appropriate number of
+[DeviceAuthorizationPollingJob](https://guillp.github.io/requests_oauth2client/api/#requests_oauth2client.device_authorization.DeviceAuthorizationPollingJob)
+will automatically obey the polling period. Everytime you call `polling_job()`, it will wait the appropriate number of
 seconds as indicated by the AS, and will apply slow-down requests.
 
 #### As Auth Handler
@@ -519,7 +519,7 @@ Endpoint until the end-user successfully authenticates:
 
 ```python
 from requests_oauth2client import (
-    BackChannelAuthenticationPoolingJob,
+    BackChannelAuthenticationPollingJob,
     BearerToken,
     OAuth2Client,
 )
@@ -539,19 +539,19 @@ ba_resp = client.backchannel_authentication_request(
 assert ba_resp.auth_req_id
 assert ba_resp.expires_in  # decreases with time
 assert ba_resp.expires_at  # a static `datetime` to keep track of the expiration date, based on "expires_in"
-assert ba_resp.interval  # the pooling interval indicated by the AS
+assert ba_resp.interval  # the polling interval indicated by the AS
 assert ba_resp.custom  # if the AS respond with additional attributes, they are also accessible
 
-pool_job = BackChannelAuthenticationPoolingJob(client, ba_resp)
+polling_job = BackChannelAuthenticationPollingJob(client, ba_resp)
 
 resp = None
 while resp is None:
-    resp = pool_job()
+    resp = polling_job()
 
 assert isinstance(resp, BearerToken)
 ```
 
-Hints by the AS to slow down pooling will automatically be obeyed.
+Hints by the AS to slow down polling will automatically be obeyed.
 
 ### Token Exchange
 

--- a/requests_oauth2client/__init__.py
+++ b/requests_oauth2client/__init__.py
@@ -67,7 +67,11 @@ from .client_authentication import (
     PublicApp,
     UnsupportedClientCredentials,
 )
-from .deprecated import DeprecatedClassMeta
+from .deprecated import (  # type: ignore[attr-defined]
+    BackChannelAuthenticationPoolingJob,
+    BaseTokenEndpointPoolingJob,
+    DeviceAuthorizationPoolingJob,
+)
 from .device_authorization import (
     DeviceAuthorizationPollingJob,
     DeviceAuthorizationResponse,
@@ -151,19 +155,6 @@ from .utils import (
     validate_endpoint_uri,
     validate_issuer_uri,
 )
-
-
-class BackChannelAuthenticationPoolingJob(metaclass=DeprecatedClassMeta):
-    _DeprecatedClassMeta__alias = BackChannelAuthenticationPollingJob
-
-
-class BaseTokenEndpointPoolingJob(metaclass=DeprecatedClassMeta):
-    _DeprecatedClassMeta__alias = BaseTokenEndpointPollingJob
-
-
-class DeviceAuthorizationPoolingJob(metaclass=DeprecatedClassMeta):
-     _DeprecatedClassMeta__alias = DeviceAuthorizationPollingJob
-
 
 __all__ = [
     "AccessDenied",

--- a/requests_oauth2client/__init__.py
+++ b/requests_oauth2client/__init__.py
@@ -32,7 +32,7 @@ from .authorization_request import (
     UnsupportedResponseTypeParam,
 )
 from .backchannel_authentication import (
-    BackChannelAuthenticationPoolingJob,
+    BackChannelAuthenticationPollingJob,
     BackChannelAuthenticationResponse,
 )
 from .client import (
@@ -67,8 +67,9 @@ from .client_authentication import (
     PublicApp,
     UnsupportedClientCredentials,
 )
+from .deprecated import DeprecatedClassMeta
 from .device_authorization import (
-    DeviceAuthorizationPoolingJob,
+    DeviceAuthorizationPollingJob,
     DeviceAuthorizationResponse,
 )
 from .discovery import (
@@ -127,8 +128,8 @@ from .exceptions import (
     UnsupportedTokenType,
     UseDPoPNonce,
 )
-from .pooling import (
-    BaseTokenEndpointPoolingJob,
+from .polling import (
+    BaseTokenEndpointPollingJob,
 )
 from .tokens import (
     BearerToken,
@@ -151,6 +152,19 @@ from .utils import (
     validate_issuer_uri,
 )
 
+
+class BackChannelAuthenticationPoolingJob(metaclass=DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = BackChannelAuthenticationPollingJob
+
+
+class BaseTokenEndpointPoolingJob(metaclass=DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = BaseTokenEndpointPollingJob
+
+
+class DeviceAuthorizationPoolingJob(metaclass=DeprecatedClassMeta):
+     _DeprecatedClassMeta__alias = DeviceAuthorizationPollingJob
+
+
 __all__ = [
     "AccessDenied",
     "AccountSelectionRequired",
@@ -161,10 +175,12 @@ __all__ = [
     "AuthorizationResponse",
     "AuthorizationResponseError",
     "BackChannelAuthenticationError",
+    "BackChannelAuthenticationPollingJob",
     "BackChannelAuthenticationPoolingJob",
     "BackChannelAuthenticationResponse",
     "BaseClientAssertionAuthenticationMethod",
     "BaseClientAuthenticationMethod",
+    "BaseTokenEndpointPollingJob",
     "BaseTokenEndpointPoolingJob",
     "BearerToken",
     "BearerTokenSerializer",
@@ -176,6 +192,7 @@ __all__ = [
     "DPoPKey",
     "DPoPToken",
     "DeviceAuthorizationError",
+    "DeviceAuthorizationPollingJob",
     "DeviceAuthorizationPoolingJob",
     "DeviceAuthorizationResponse",
     "EncryptionAlgs",

--- a/requests_oauth2client/auth.py
+++ b/requests_oauth2client/auth.py
@@ -364,16 +364,16 @@ class OAuth2DeviceCodeAuth(OAuth2AccessTokenAuth):  # type: ignore[override]
         This will poll the Token Endpoint until the user finishes the authorization process.
 
         """
-        from .device_authorization import DeviceAuthorizationPoolingJob
+        from .device_authorization import DeviceAuthorizationPollingJob
 
         if self.device_code:  # pragma: no branch
-            pooling_job = DeviceAuthorizationPoolingJob(
+            polling_job = DeviceAuthorizationPollingJob(
                 client=self.client,
                 device_code=self.device_code,
                 interval=self.interval,
             )
             token = None
             while token is None:
-                token = pooling_job()
+                token = polling_job()
             self.token = token
             self.device_code = None

--- a/requests_oauth2client/backchannel_authentication.py
+++ b/requests_oauth2client/backchannel_authentication.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from attrs import define
 
-from .pooling import BaseTokenEndpointPoolingJob
+from .polling import BaseTokenEndpointPollingJob
 from .utils import accepts_expires_in
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ class BackChannelAuthenticationResponse:
         auth_req_id: the `auth_req_id` as returned by the AS.
         expires_at: the date when the `auth_req_id` expires.
             Note that this request also accepts an `expires_in` parameter, in seconds.
-        interval: the Token Endpoint pooling interval, in seconds, as returned by the AS.
+        interval: the Token Endpoint polling interval, in seconds, as returned by the AS.
         **kwargs: any additional custom parameters as returned by the AS.
 
     """
@@ -94,18 +94,18 @@ class BackChannelAuthenticationResponse:
 
 
 @define(init=False)
-class BackChannelAuthenticationPoolingJob(BaseTokenEndpointPoolingJob):
-    """A pooling job for the BackChannel Authentication flow.
+class BackChannelAuthenticationPollingJob(BaseTokenEndpointPollingJob):
+    """A polling job for the BackChannel Authentication flow.
 
     This will poll the Token Endpoint until the user finishes with its authentication.
 
     Args:
         client: an OAuth2Client that will be used to pool the token endpoint.
         auth_req_id: an `auth_req_id` as `str` or a `BackChannelAuthenticationResponse`.
-        interval: The pooling interval, in seconds, to use. This overrides
+        interval: The polling interval, in seconds, to use. This overrides
             the one in `auth_req_id` if it is a `BackChannelAuthenticationResponse`.
             Defaults to 5 seconds.
-        slow_down_interval: Number of seconds to add to the pooling interval when the AS returns
+        slow_down_interval: Number of seconds to add to the polling interval when the AS returns
             a slow down request.
         requests_kwargs: Additional parameters for the underlying calls to [requests.request][].
         **token_kwargs: Additional parameters for the token request.
@@ -113,14 +113,14 @@ class BackChannelAuthenticationPoolingJob(BaseTokenEndpointPoolingJob):
     Example:
         ```python
         client = OAuth2Client(token_endpoint="https://my.as.local/token", auth=("client_id", "client_secret"))
-        pool_job = BackChannelAuthenticationPoolingJob(
+        polling_job = BackChannelAuthenticationPollingJob(
             client=client,
             auth_req_id="my_auth_req_id",
         )
 
         token = None
         while token is None:
-            token = pool_job()
+            token = polling_job()
         ```
 
     """

--- a/requests_oauth2client/deprecated.py
+++ b/requests_oauth2client/deprecated.py
@@ -1,0 +1,52 @@
+"""Mark a class as deprecated.
+
+https://stackoverflow.com/a/52087847
+"""
+from warnings import warn
+
+
+class DeprecatedClassMeta(type):
+    def __new__(cls, name, bases, classdict, *args, **kwargs):
+        alias = classdict.get("_DeprecatedClassMeta__alias")
+
+        if alias is not None:
+            def new(cls, *args, **kwargs):
+                alias = cls._DeprecatedClassMeta__alias
+
+                if alias is not None:
+                    warn(f"{cls.__name__} has been renamed to {alias.__name__}, the alias will be "
+                         "removed in the future", DeprecationWarning, stacklevel=2)
+
+                return alias(*args, **kwargs)
+
+            classdict["__new__"] = new
+            classdict["__doc__"] = f"(Use {alias.__name__} instead of this class)"
+            classdict["_DeprecatedClassMeta__alias"] = alias
+
+        fixed_bases = []
+
+        for b in bases:
+            alias = getattr(b, "_DeprecatedClassMeta__alias", None)
+
+            if alias is not None:
+                warn(f"{b.__name__} has been renamed to {alias.__name__}, the alias will be "
+                     "removed in the future", DeprecationWarning, stacklevel=2)
+
+            # Avoid duplicate base classes.
+            b = alias or b
+            if b not in fixed_bases:
+                fixed_bases.append(b)
+
+        fixed_bases = tuple(fixed_bases)
+
+        return super().__new__(cls, name, fixed_bases, classdict,
+                               *args, **kwargs)
+
+    def __instancecheck__(cls, instance):
+        return any(cls.__subclasscheck__(c)
+            for c in {type(instance), instance.__class__})
+
+    def __subclasscheck__(cls, subclass):
+        if subclass is cls:
+            return True
+        return issubclass(subclass, cls._DeprecatedClassMeta__alias)

--- a/requests_oauth2client/deprecated.py
+++ b/requests_oauth2client/deprecated.py
@@ -1,21 +1,32 @@
+# ruff: noqa: PGH003,ANN001,ANN002,ANN003,ANN202,ANN204,D101
+# type: ignore
 """Mark a class as deprecated.
 
 https://stackoverflow.com/a/52087847
 """
+
 from warnings import warn
 
+from .backchannel_authentication import BackChannelAuthenticationPollingJob
+from .device_authorization import DeviceAuthorizationPollingJob
+from .polling import BaseTokenEndpointPollingJob
 
-class DeprecatedClassMeta(type):
+
+class _DeprecatedClassMeta(type):
     def __new__(cls, name, bases, classdict, *args, **kwargs):
         alias = classdict.get("_DeprecatedClassMeta__alias")
 
         if alias is not None:
+
             def new(cls, *args, **kwargs):
                 alias = cls._DeprecatedClassMeta__alias
 
                 if alias is not None:
-                    warn(f"{cls.__name__} has been renamed to {alias.__name__}, the alias will be "
-                         "removed in the future", DeprecationWarning, stacklevel=2)
+                    warn(
+                        f"{cls.__name__} has been renamed to {alias.__name__}, the alias will be removed in the future",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
 
                 return alias(*args, **kwargs)
 
@@ -29,24 +40,44 @@ class DeprecatedClassMeta(type):
             alias = getattr(b, "_DeprecatedClassMeta__alias", None)
 
             if alias is not None:
-                warn(f"{b.__name__} has been renamed to {alias.__name__}, the alias will be "
-                     "removed in the future", DeprecationWarning, stacklevel=2)
+                warn(
+                    f"{b.__name__} has been renamed to {alias.__name__}, the alias will be removed in the future",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
             # Avoid duplicate base classes.
-            b = alias or b
+            b = alias or b  # noqa: PLW2901
             if b not in fixed_bases:
                 fixed_bases.append(b)
 
         fixed_bases = tuple(fixed_bases)
 
-        return super().__new__(cls, name, fixed_bases, classdict,
-                               *args, **kwargs)
+        return super().__new__(cls, name, fixed_bases, classdict, *args, **kwargs)
 
     def __instancecheck__(cls, instance):
-        return any(cls.__subclasscheck__(c)
-            for c in {type(instance), instance.__class__})
+        return any(cls.__subclasscheck__(c) for c in {type(instance), instance.__class__})
 
     def __subclasscheck__(cls, subclass):
         if subclass is cls:
             return True
         return issubclass(subclass, cls._DeprecatedClassMeta__alias)
+
+
+class BackChannelAuthenticationPoolingJob(metaclass=_DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = BackChannelAuthenticationPollingJob
+
+
+class BaseTokenEndpointPoolingJob(metaclass=_DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = BaseTokenEndpointPollingJob
+
+
+class DeviceAuthorizationPoolingJob(metaclass=_DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = DeviceAuthorizationPollingJob
+
+
+__all__ = [
+    "BackChannelAuthenticationPoolingJob",
+    "BaseTokenEndpointPoolingJob",
+    "DeviceAuthorizationPoolingJob",
+]

--- a/requests_oauth2client/device_authorization.py
+++ b/requests_oauth2client/device_authorization.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from attrs import define
 
-from .pooling import BaseTokenEndpointPoolingJob
+from .polling import BaseTokenEndpointPollingJob
 from .utils import accepts_expires_in
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class DeviceAuthorizationResponse:
         verification_uri_complete: the `device_code` as returned by the AS.
         expires_at: the expiration date for the device_code.
             Also accepts an `expires_in` parameter, as a number of seconds in the future.
-        interval: the pooling `interval` as returned by the AS.
+        interval: the polling `interval` as returned by the AS.
         **kwargs: additional parameters as returned by the AS.
 
     """
@@ -69,8 +69,8 @@ class DeviceAuthorizationResponse:
 
 
 @define(init=False)
-class DeviceAuthorizationPoolingJob(BaseTokenEndpointPoolingJob):
-    """A Token Endpoint pooling job for the Device Authorization Flow.
+class DeviceAuthorizationPollingJob(BaseTokenEndpointPollingJob):
+    """A Token Endpoint polling job for the Device Authorization Flow.
 
     This periodically checks if the user has finished with his authorization in a Device
     Authorization flow.
@@ -78,19 +78,19 @@ class DeviceAuthorizationPoolingJob(BaseTokenEndpointPoolingJob):
     Args:
         client: an OAuth2Client that will be used to pool the token endpoint.
         device_code: a `device_code` as `str` or a `DeviceAuthorizationResponse`.
-        interval: The pooling interval to use. This overrides the one in `auth_req_id` if it is
+        interval: The polling interval to use. This overrides the one in `auth_req_id` if it is
             a `BackChannelAuthenticationResponse`.
-        slow_down_interval: Number of seconds to add to the pooling interval when the AS returns
+        slow_down_interval: Number of seconds to add to the polling interval when the AS returns
             a slow-down request.
         requests_kwargs: Additional parameters for the underlying calls to [requests.request][].
         **token_kwargs: Additional parameters for the token request.
 
     Example:
         ```python
-        from requests_oauth2client import DeviceAuthorizationPoolingJob, OAuth2Client
+        from requests_oauth2client import DeviceAuthorizationPollingJob, OAuth2Client
 
         client = OAuth2Client(token_endpoint="https://my.as.local/token", auth=("client_id", "client_secret"))
-        pooler = DeviceAuthorizationPoolingJob(client=client, device_code="my_device_code")
+        pooler = DeviceAuthorizationPollingJob(client=client, device_code="my_device_code")
 
         token = None
         while token is None:

--- a/requests_oauth2client/polling.py
+++ b/requests_oauth2client/polling.py
@@ -1,4 +1,4 @@
-"""Contains base classes for pooling jobs."""
+"""Contains base classes for polling jobs."""
 
 from __future__ import annotations
 
@@ -15,14 +15,14 @@ if TYPE_CHECKING:
 
 
 @define
-class BaseTokenEndpointPoolingJob:
-    """Base class for Token Endpoint pooling jobs.
+class BaseTokenEndpointPollingJob:
+    """Base class for Token Endpoint polling jobs.
 
     This is used for decoupled flows like CIBA or Device Authorization.
 
     This class must be subclassed to implement actual BackChannel flows. This needs an
     [OAuth2Client][requests_oauth2client.client.OAuth2Client] that will be used to pool the token
-    endpoint. The initial pooling `interval` is configurable.
+    endpoint. The initial polling `interval` is configurable.
 
     """
 
@@ -33,11 +33,11 @@ class BaseTokenEndpointPoolingJob:
     interval: int
 
     def __call__(self) -> BearerToken | None:
-        """Wrap the actual Token Endpoint call with a pooling interval.
+        """Wrap the actual Token Endpoint call with a polling interval.
 
-        Everytime this method is called, it will wait for the entire duration of the pooling
+        Everytime this method is called, it will wait for the entire duration of the polling
         interval before calling
-        [token_request()][requests_oauth2client.pooling.TokenEndpointPoolingJob.token_request]. So
+        [token_request()][requests_oauth2client.polling.TokenEndpointPollingJob.token_request]. So
         you can call it immediately after initiating the BackChannel flow, and it will wait before
         initiating the first call.
 
@@ -69,7 +69,7 @@ class BaseTokenEndpointPoolingJob:
     def slow_down(self) -> None:
         """Implement the behavior when receiving a 'slow_down' response from the AS.
 
-        By default, it increases the pooling interval by the slow down interval.
+        By default, it increases the polling interval by the slow down interval.
 
         """
         self.interval += self.slow_down_interval
@@ -86,8 +86,8 @@ class BaseTokenEndpointPoolingJob:
 
         Subclasses must implement this. This method must raise
         [AuthorizationPending][requests_oauth2client.exceptions.AuthorizationPending] to retry after
-        the pooling interval, or [SlowDown][requests_oauth2client.exceptions.SlowDown] to increase
-        the pooling interval by `slow_down_interval` seconds.
+        the polling interval, or [SlowDown][requests_oauth2client.exceptions.SlowDown] to increase
+        the polling interval by `slow_down_interval` seconds.
 
         Returns:
             a [BearerToken][requests_oauth2client.tokens.BearerToken]

--- a/tests/test_deprecated_metaclass.py
+++ b/tests/test_deprecated_metaclass.py
@@ -1,0 +1,54 @@
+# ruff: noqa: PGH003,ANN001,ANN002,ANN003,ANN201,ANN202,ANN204,D101
+# type: ignore
+"""Test the metaclass used to deprecated things.
+
+https://stackoverflow.com/a/52087847 by
+Kentzo https://stackoverflow.com/users/188530/kentzo
+"""
+
+from requests_oauth2client.deprecated import _DeprecatedClassMeta
+
+
+class NewClass:
+    foo = 1
+
+
+class NewClassSubclass(NewClass):
+    pass
+
+
+class DeprecatedClass(metaclass=_DeprecatedClassMeta):
+    _DeprecatedClassMeta__alias = NewClass
+
+
+class DeprecatedClassSubclass(DeprecatedClass):
+    foo = 2
+
+
+class DeprecatedClassSubSubclass(DeprecatedClassSubclass):
+    foo = 3
+
+
+def test_deprecating_metaclass():
+    assert issubclass(DeprecatedClass, DeprecatedClass)
+    assert issubclass(DeprecatedClassSubclass, DeprecatedClass)
+    assert issubclass(DeprecatedClassSubSubclass, DeprecatedClass)
+    assert issubclass(NewClass, DeprecatedClass)
+    assert issubclass(NewClassSubclass, DeprecatedClass)
+
+    assert issubclass(DeprecatedClassSubclass, NewClass)
+    assert issubclass(DeprecatedClassSubSubclass, NewClass)
+
+    assert isinstance(DeprecatedClass(), DeprecatedClass)
+    assert isinstance(DeprecatedClassSubclass(), DeprecatedClass)
+    assert isinstance(DeprecatedClassSubSubclass(), DeprecatedClass)
+    assert isinstance(NewClass(), DeprecatedClass)
+    assert isinstance(NewClassSubclass(), DeprecatedClass)
+
+    assert isinstance(DeprecatedClassSubclass(), NewClass)
+    assert isinstance(DeprecatedClassSubSubclass(), NewClass)
+
+    assert NewClass().foo == 1
+    assert DeprecatedClass().foo == 1
+    assert DeprecatedClassSubclass().foo == 2
+    assert DeprecatedClassSubSubclass().foo == 3

--- a/tests/test_deprecated_names.py
+++ b/tests/test_deprecated_names.py
@@ -1,0 +1,60 @@
+"""An attempt to use old class names should generate DeprecationWarning."""
+import secrets
+
+import pytest
+from requests_mock import Mocker
+
+from requests_oauth2client import (
+    DeviceAuthorizationPoolingJob,  # old spelling
+    OAuth2Client,
+)
+from tests.conftest import FixtureRequest, join_url
+
+
+@pytest.fixture(params=["device", "oauth/device"])
+def device_authorization_endpoint(request: FixtureRequest, issuer: str) -> str:
+    return join_url(issuer, request.param)
+
+
+def test_device_authorization_deprecated(
+    requests_mock: Mocker,
+    device_authorization_endpoint: str,
+    token_endpoint: str,
+    client_id: str,
+    client_secret: str,
+) -> None:
+    device_code = secrets.token_urlsafe()
+    user_code = secrets.token_urlsafe(6)
+    verification_uri = "https://test.com/verify_device"
+
+    client = OAuth2Client(
+        token_endpoint=token_endpoint,
+        device_authorization_endpoint=device_authorization_endpoint,
+        auth=(client_id, client_secret),
+    )
+
+    requests_mock.post(
+        device_authorization_endpoint,
+        json={
+            "device_code": device_code,
+            "user_code": user_code,
+            "verification_uri": verification_uri,
+            "expires_in": 3600,
+            "interval": 1,
+        },
+    )
+    device_auth_resp = client.authorize_device()
+    requests_mock.post(
+        token_endpoint,
+        [
+            {"json": {"error": "authorization_pending"}, "status_code": 400},
+        ],
+    )
+
+    with pytest.deprecated_call():
+        DeviceAuthorizationPoolingJob(
+            client,
+            device_auth_resp,
+            interval=1,
+            slow_down_interval=2,
+        )

--- a/tests/test_device_authorization.py
+++ b/tests/test_device_authorization.py
@@ -8,7 +8,7 @@ from requests_oauth2client import (
     BearerToken,
     ClientSecretBasic,
     DeviceAuthorizationError,
-    DeviceAuthorizationPoolingJob,
+    DeviceAuthorizationPollingJob,
     InvalidDeviceAuthorizationResponse,
     OAuth2Client,
     PublicApp,
@@ -77,7 +77,7 @@ def test_device_authorization(
         ],
     )
 
-    pool_job = DeviceAuthorizationPoolingJob(
+    polling_job = DeviceAuthorizationPollingJob(
         client,
         device_auth_resp,
         interval=1,
@@ -85,27 +85,27 @@ def test_device_authorization(
     )
 
     # 1st attempt: authorization_pending
-    resp = pool_job()
+    resp = polling_job()
     assert requests_mock.last_request is not None
     params = Query(requests_mock.last_request.text).params
     assert params.get("client_id") == client_id
     assert params.get("client_secret") == client_secret
 
-    assert pool_job.interval == 1
+    assert polling_job.interval == 1
     assert resp is None
 
     # 2nd attempt: slow down
-    resp = pool_job()
+    resp = polling_job()
     assert requests_mock.last_request is not None
     params = Query(requests_mock.last_request.text).params
     assert params.get("client_id") == client_id
     assert params.get("client_secret") == client_secret
 
-    assert pool_job.interval == 3
+    assert polling_job.interval == 3
     assert resp is None
 
     # 3rd attempt: access token delivered
-    resp = pool_job()
+    resp = polling_job()
     assert isinstance(resp, BearerToken)
     assert requests_mock.last_request is not None
     params = Query(requests_mock.last_request.text).params

--- a/tests/unit_tests/test_backchannel_authentication.py
+++ b/tests/unit_tests/test_backchannel_authentication.py
@@ -8,7 +8,7 @@ import pytest
 from freezegun import freeze_time
 
 from requests_oauth2client import (
-    BackChannelAuthenticationPoolingJob,
+    BackChannelAuthenticationPollingJob,
     BackChannelAuthenticationResponse,
     BaseClientAuthenticationMethod,
     BearerToken,
@@ -264,7 +264,7 @@ def test_backchannel_authentication_invalid_scope(bca_client: OAuth2Client) -> N
         )
 
 
-def test_pooling_job(
+def test_polling_job(
     requests_mock: RequestsMocker,
     bca_client: OAuth2Client,
     token_endpoint: str,
@@ -275,11 +275,11 @@ def test_pooling_job(
     mocker: MockerFixture,
 ) -> None:
     interval = 20
-    job = BackChannelAuthenticationPoolingJob(client=bca_client, auth_req_id=auth_req_id, interval=interval)
+    job = BackChannelAuthenticationPollingJob(client=bca_client, auth_req_id=auth_req_id, interval=interval)
     assert job.interval == interval
     assert job.slow_down_interval == 5
 
-    assert job == BackChannelAuthenticationPoolingJob(
+    assert job == BackChannelAuthenticationPollingJob(
         bca_client,
         BackChannelAuthenticationResponse(auth_req_id, interval=interval),
     )

--- a/tests/unit_tests/test_device_authorization.py
+++ b/tests/unit_tests/test_device_authorization.py
@@ -10,7 +10,7 @@ from requests_oauth2client import (
     BearerToken,
     ClientSecretPost,
     DeviceAuthorizationError,
-    DeviceAuthorizationPoolingJob,
+    DeviceAuthorizationPollingJob,
     DeviceAuthorizationResponse,
     InvalidDeviceAuthorizationResponse,
     OAuth2Client,
@@ -201,7 +201,7 @@ def test_device_authorization_invalid_errors(
 
 
 @freeze_time()
-def test_device_authorization_pooling_job(
+def test_device_authorization_polling_job(
     requests_mock: RequestsMocker,
     token_endpoint: str,
     client_id: str,
@@ -214,7 +214,7 @@ def test_device_authorization_pooling_job(
 ) -> None:
     interval = 20
     client = OAuth2Client(token_endpoint, auth=(client_id, client_secret))
-    job = DeviceAuthorizationPoolingJob(
+    job = DeviceAuthorizationPollingJob(
         client=client,
         device_code=device_code,
         interval=interval,
@@ -222,7 +222,7 @@ def test_device_authorization_pooling_job(
     assert job.interval == interval
     assert job.slow_down_interval == 5
 
-    assert job == DeviceAuthorizationPoolingJob(
+    assert job == DeviceAuthorizationPollingJob(
         client,
         DeviceAuthorizationResponse(
             device_code=device_code, user_code="foo", verification_uri="https://foo.bar", interval=interval


### PR DESCRIPTION
Sorry to provide a quite large pull request that basically is a pure linguistic change, but I think we should be using "polling" instead of "pooling, pool".

From https://en.wiktionary.org/:

pool (plural pools), a noun:
  (...)
  4. (by extension, computing) A set of resources that are kept ready to use.

poll, a verb: (...)
  9. (transitive, computing, communication)
  To (repeatedly) request the status of something (such as a computer or
  printer on a network).

Old class names are kept for compatibility and will cause a DeprecationWarning.