### PR TITLE
Set a timeout on client HTTP calls

### DIFF
--- a/requests_oauth2client/client.py
+++ b/requests_oauth2client/client.py
@@ -1927,10 +1927,10 @@ Invalid `token_type_hint`. To test arbitrary `token_type_hint` values, you must 
             validate_endpoint_uri(url, path=False)
 
         session = session or requests.Session()
-        discovery = session.get(url).json()
+        discovery = session.get(url, timeout=10.0).json()
 
         jwks_uri = discovery.get("jwks_uri")
-        jwks = JwkSet(session.get(jwks_uri).json()) if jwks_uri else None
+        jwks = JwkSet(session.get(jwks_uri, timeout=10.0).json()) if jwks_uri else None
 
         return cls.from_discovery_document(
             discovery,

--- a/tests/unit_tests/test_auth.py
+++ b/tests/unit_tests/test_auth.py
@@ -30,7 +30,7 @@ def test_bearer_auth(
     access_token: str,
 ) -> None:
     requests_mock.post(target_api)
-    response = requests.post(target_api, auth=bearer_token)
+    response = requests.post(target_api, auth=bearer_token, timeout=10.0)
     assert response.ok
     assert requests_mock.last_request is not None
     assert requests_mock.last_request.headers.get("Authorization") == f"Bearer {access_token}"
@@ -39,7 +39,7 @@ def test_bearer_auth(
 def test_expired_token(minutes_ago: datetime) -> None:
     token = BearerToken(access_token="foo", expires_at=minutes_ago)
     with pytest.raises(ExpiredAccessToken):
-        requests.post("http://localhost/test", auth=token)
+        requests.post("http://localhost/test", auth=token, timeout=10.0)
 
 
 def test_access_token_auth(
@@ -72,7 +72,7 @@ def test_access_token_auth(
             "token_type": "Bearer",
         },
     )
-    requests.post(target_uri, auth=auth)
+    requests.post(target_uri, auth=auth, timeout=10.0)
 
     assert len(requests_mock.request_history) == 2
     refresh_request = requests_mock.request_history[0]
@@ -120,7 +120,7 @@ def test_client_credentials_auth(
             "token_type": "Bearer",
         },
     )
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
 
     assert len(requests_mock.request_history) == 2
     cc_request = requests_mock.request_history[0]
@@ -140,7 +140,7 @@ def test_client_credentials_auth(
     assert auth.token.refresh_token == refresh_token
 
     requests_mock.reset_mock()
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
     assert len(requests_mock.request_history) == 1
 
     assert OAuth2ClientCredentialsAuth(client, token=access_token).token == BearerToken(access_token)
@@ -174,7 +174,7 @@ def test_authorization_code_auth(
             "token_type": "Bearer",
         },
     )
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
 
     assert len(requests_mock.request_history) == 2
     code_request = requests_mock.request_history[0]
@@ -195,7 +195,7 @@ def test_authorization_code_auth(
     assert auth.token.refresh_token == refresh_token
 
     requests_mock.reset_mock()
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
     assert len(requests_mock.request_history) == 1
 
     assert OAuth2AuthorizationCodeAuth(client, code=authorization_code, token=access_token).token == BearerToken(
@@ -238,7 +238,7 @@ def test_ropc_auth(
     )
     requests_mock.post(target_api)
 
-    assert requests.post(target_api, auth=auth).ok
+    assert requests.post(target_api, auth=auth, timeout=10.0).ok
 
     assert len(requests_mock.request_history) == 2
 
@@ -257,7 +257,7 @@ def test_ropc_auth(
     assert auth.token.refresh_token == refresh_token
 
     requests_mock.reset_mock()
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
     assert requests_mock.last_request is not None
     assert requests_mock.last_request.url == target_api
 
@@ -315,7 +315,7 @@ def test_device_code_auth(
     assert auth.device_code is da_resp.device_code
     assert auth.token is None
 
-    assert requests.post(target_api, auth=auth)
+    assert requests.post(target_api, auth=auth, timeout=10.0)
     assert len(requests_mock.request_history) == 2
     device_code_request = requests_mock.request_history[0]
     api_request = requests_mock.request_history[1]
@@ -335,13 +335,13 @@ def test_device_code_auth(
     assert auth.token.refresh_token == refresh_token
 
     requests_mock.reset_mock()
-    requests.post(target_api, auth=auth)
+    requests.post(target_api, auth=auth, timeout=10.0)
     assert requests_mock.last_request is not None
     assert requests_mock.last_request.url == target_api
 
     auth.forget_token()
     with pytest.raises(NonRenewableTokenError):
-        requests.post(target_api, auth=auth)
+        requests.post(target_api, auth=auth, timeout=10.0)
 
     assert OAuth2DeviceCodeAuth(oauth2client, device_code=device_code, token=access_token).token == BearerToken(
         access_token

--- a/tests/unit_tests/test_client.py
+++ b/tests/unit_tests/test_client.py
@@ -1202,7 +1202,7 @@ def test_proxy_authorization(requests_mock: RequestsMocker, target_api: str) -> 
 
     requests_mock.post(target_api)
 
-    requests.post(target_api, auth=ProxyAuthorizationBearerToken(access_token))
+    requests.post(target_api, auth=ProxyAuthorizationBearerToken(access_token), timeout=10.0)
     assert requests_mock.last_request is not None
     assert requests_mock.last_request.headers[auth_header] == f"Bearer {access_token}"
 

--- a/tests/unit_tests/test_client_authentication.py
+++ b/tests/unit_tests/test_client_authentication.py
@@ -161,7 +161,7 @@ def test_public_client(
 def test_invalid_request(requests_mock: RequestsMocker, client_id: str, client_secret: str) -> None:
     requests_mock.get(ANY)
     with pytest.raises(RuntimeError) as exc:
-        requests.get("http://localhost", auth=ClientSecretBasic(client_id, client_secret))
+        requests.get("http://localhost", auth=ClientSecretBasic(client_id, client_secret), timeout=10.0)
     assert exc.type is InvalidRequestForClientAuthentication
 
 

--- a/tests/unit_tests/test_dpop.py
+++ b/tests/unit_tests/test_dpop.py
@@ -94,7 +94,7 @@ def test_dpop_token_api_request(requests_mock: RequestsMocker, alg: str) -> None
 
     target_api = "https://my.api/resource"
     requests_mock.put(target_api)
-    requests.put(target_api, params={"key": "value"}, auth=dpop_token)
+    requests.put(target_api, params={"key": "value"}, auth=dpop_token, timeout=10.0)
     assert requests_mock.called_once
     api_request = requests_mock.last_request
     assert api_request is not None
@@ -495,7 +495,7 @@ def test_dpop_with_rs_provided_nonce(
     session = requests.Session()
     session.auth = OAuth2ClientCredentialsAuth(oauth2client, dpop=True)
 
-    response = session.post(target_api)
+    response = session.post(target_api, timeout=10.0)
     assert response.status_code == 200
     assert requests_mock.call_count == 3
 
@@ -512,7 +512,7 @@ def test_dpop_with_rs_provided_nonce(
     assert proof_with_nonce.claims["nonce"] == dpop_nonce
 
     requests_mock.reset_mock()
-    second_response = session.post(target_api)
+    second_response = session.post(target_api, timeout=10.0)
     assert second_response.status_code == 200
     assert requests_mock.called_once
     assert requests_mock.last_request is not None
@@ -644,7 +644,7 @@ def test_rs_missing_nonce(requests_mock: RequestsMocker, target_api: str) -> Non
     dpop_token = DPoPToken(access_token="my_dpop_access_token", _dpop_key=dpop_key)
 
     with pytest.raises(MissingDPoPNonce):
-        requests.get(target_api, auth=dpop_token)
+        requests.get(target_api, auth=dpop_token, timeout=10.0)
 
 
 def test_rs_repeated_nonce(requests_mock: RequestsMocker, target_api: str) -> None:
@@ -663,7 +663,7 @@ def test_rs_repeated_nonce(requests_mock: RequestsMocker, target_api: str) -> No
     dpop_token = DPoPToken(access_token="my_dpop_access_token", _dpop_key=dpop_key)
 
     with pytest.raises(RepeatedDPoPNonce):
-        requests.get(target_api, auth=dpop_token)
+        requests.get(target_api, auth=dpop_token, timeout=10.0)
 
 
 def test_rs_dpop_nonce_loop(
@@ -700,6 +700,6 @@ def test_rs_dpop_nonce_loop(
     dpop_key = DPoPKey.generate()
     dpop_token = DPoPToken(access_token="my_dpop_access_token", _dpop_key=dpop_key)
 
-    resp = requests.get(target_api, auth=dpop_token)
+    resp = requests.get(target_api, auth=dpop_token, timeout=10.0)
     assert resp.status_code == 401
     assert resp.headers["DPoP-Nonce"] == "nonce2"


### PR DESCRIPTION
I ran into this while reading through the code path around requests_oauth2client/client.py. Set a timeout on client HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.